### PR TITLE
Fixes for build and runtime issues with Flutter dev/master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ build/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+ios/Flutter/flutter_export_environment.sh

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -6,6 +6,9 @@ import 'package:playground_flutter/store/store.dart';
 
 class Environment {
   static setup() async {
+    // Make sure that the binary messenger binding are properly initialiazed
+    WidgetsFlutterBinding.ensureInitialized();
+
     // lock orientation position
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitDown,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   webview_flutter:
   flutter_redux:
   redux_logging:
-  get_it:
+  get_it: ^1.1.0
   flushbar: ^1.7.1+1
   mapbox_gl: ^0.0.3
   sqflite: ^1.1.0


### PR DESCRIPTION
There are some issue when building and running this project with the latest master snapshot of Flutter. It  was caused by one breaking change introduced on Flutter a month ago (https://groups.google.com/forum/#!msg/flutter-announce/sHAL2fBtJ1Y/mGjrKH3dEwAJ) and breaking change introduced by the latest `get_it` package since the version are not restricted in this project `pubspec.yaml`.